### PR TITLE
Add pre-release workflow and bump version to 0.12.0-alpha.1

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,104 @@
+name: Pre-Release
+
+on:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+    - name: Dump upload url to file
+      run: echo '${{ steps.create_release.outputs.upload_url }}' > upload_url
+    - name: Upload upload_url
+      uses: actions/upload-artifact@v1
+      with:
+        name: upload_url
+        path: upload_url
+
+  build:
+    needs: create-release
+    strategy:
+      matrix:
+        platform: [
+          'linux-arm',
+          'linux-arm64',
+          'linux-x64',
+          'darwin-x64',
+        ]
+        pair: [
+          'node:10',
+          'node:12',
+          'node:14',
+        ]
+        include:
+          - platform: 'linux-arm'
+            host-os: 'ubuntu-latest'
+          - platform: 'linux-arm64'
+            host-os: 'ubuntu-latest'
+          - platform: 'linux-x64'
+            host-os: 'ubuntu-latest'
+          - platform: 'darwin-x64'
+            host-os: 'macos-latest'
+          - pair: 'node:10'
+            language: 'node'
+            version: '10'
+          - pair: 'node:12'
+            language: 'node'
+            version: '12'
+          - pair: 'node:14'
+            language: 'node'
+            version: '14'
+
+    runs-on: ${{ matrix.host-os }}
+
+    steps:
+    - name: Download upload_url
+      uses: actions/download-artifact@v1
+      with:
+        name: upload_url
+    - name: Set upload_url
+      run: echo "UPLOAD_URL=$(cat upload_url/upload_url)" >> $GITHUB_ENV
+    - name: Set release version
+      run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.version }}
+    - name: Build adapter
+      run: |
+        ./build.sh "${{ matrix.platform }}" "${{ matrix.language }}" "${{ matrix.version }}"
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ env.UPLOAD_URL }}
+        asset_path: homekit-adapter-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}-v${{ matrix.version }}.tgz
+        asset_name: homekit-adapter-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}-v${{ matrix.version }}.tgz
+        asset_content_type: application/zip
+    - name: Upload Release Asset Checksum
+      id: upload-release-asset-checksum
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ env.UPLOAD_URL }}
+        asset_path: homekit-adapter-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}-v${{ matrix.version }}.tgz.sha256sum
+        asset_name: homekit-adapter-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}-v${{ matrix.version }}.tgz.sha256sum
+        asset_content_type: text/plain

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homekit-adapter",
-  "version": "0.11.0",
+  "version": "0.12.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homekit-adapter",
-  "version": "0.11.0",
+  "version": "0.12.0-alpha.1",
   "description": "HomeKit device adapter.",
   "author": "WebThingsIO",
   "main": "index.js",


### PR DESCRIPTION
r=me

Landing this in order to generate a cross-platform pre-release build to test the changes in https://github.com/WebThingsIO/homekit-adapter/pull/63 and unblock the gateway 1.1 release.